### PR TITLE
Adapt debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ dpkg-buildpackage -us -uc<br>
 
 # Install from repositories
 ```
-curl -s https://packagecloud.io/install/repositories/rodw-au/rodw-au/script.deb.sh | sudo bash<br>
-sudo apt-get install linuxcnc-ethercat=0.9.4<br>
+curl -s https://packagecloud.io/install/repositories/rodw-au/rodw-au/script.deb.sh | sudo bash
+sudo apt-get install linuxcnc-ethercat=0.9.4
 ``` 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ sudo apt install dpkg-dev linuxcnc-uspace, ethercat-master and libethercat-dev<b
 dpkg-buildpackage -us -uc<br>
 
 # Install from repositories
-'''
+```
 curl -s https://packagecloud.io/install/repositories/rodw-au/rodw-au/script.deb.sh | sudo bash<br>
 sudo apt-get install linuxcnc-ethercat=0.9.4<br>
-''' 
+``` 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # linuxcnc-ethercat
-LinuxCNC EtherCAT HAL driver
+.DEB file for LinuxCNC EtherCAT HAL driver
+
+# build deb file
+git clone https://github.com/rodw-au/linuxcnc-ethercat
+git checkout adapt_debian
+install all dependencies (linuxcnc and libethercat must be installed<br>
+sudo apt install dpkg-dev linuxcnc-uspace, ethercat-master and libethercat-dev<br>
+dpkg-buildpackage -us -uc<br>
+
+# Install from repositories
+'''
+curl -s https://packagecloud.io/install/repositories/rodw-au/rodw-au/script.deb.sh | sudo bash<br>
+sudo apt-get install linuxcnc-ethercat=0.9.4<br>
+''' 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # linuxcnc-ethercat
-.DEB file for LinuxCNC EtherCAT HAL driver
+.DEB file for LinuxCNC EtherCAT HAL driver<br>
 
 # build deb file
-git clone https://github.com/rodw-au/linuxcnc-ethercat
-git checkout adapt_debian
+git clone https://github.com/rodw-au/linuxcnc-ethercat<br>
+git checkout adapt_debian<br>
 install all dependencies (linuxcnc and libethercat must be installed<br>
 sudo apt install dpkg-dev linuxcnc-uspace, ethercat-master and libethercat-dev<br>
 dpkg-buildpackage -us -uc<br>

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,7 @@
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
-
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 %:
 	dh $@ 


### PR DESCRIPTION
Updated rules to circmvent the following build error

```
dpkg-shlibdeps: error: no dependency information found for /usr/local/lib/libethercat.so.1 (used by debian/linuxcnc-ethercat/usr/lib/linuxcnc/modules/lcec.so)
Hint: check if the library actually comes from a package.
```

Updated README.md to add instructions 
